### PR TITLE
feat: Rerun scan on PR edited, reopened and synchronize

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
 	EVENT_ACTION=$(jq -r ".action" "${GITHUB_EVENT_PATH}")
-	if [[ "${EVENT_ACTION}" != "opened" ]]; then
+	if [[ "${EVENT_ACTION}" != "opened" && "${EVENT_ACTION}" != "edited" && "${EVENT_ACTION}" != "reopened" && "${EVENT_ACTION}" != "synchronize"  ]]; then
 		echo "No need to run analysis. It is already triggered by the push event."
 		exit
 	fi


### PR DESCRIPTION
THIS PROJECT IS IN MAINTENANCE MODE. We accept pull-requests for Bug Fixes **ONLY**. NO NEW FEATURES ACCEPTED!

---


### Description
Currently scan is not being run on any other event on a pull request other then opened. Ideally you want to re-run when changes are being made, when it gets reopened or synchronises.

### Related Issue
https://github.com/kitabisa/sonarqube-action/issues/21

Fixes #
- Run on pull request edit
- Run on pull request reopened
- Run on pull request synchronize

### Motivation and Context
It fixes the problem that when a developer makes changes to fix issues reported by SonarQube for this PR that a new scan is triggered.

https://github.com/kitabisa/sonarqube-action/issues/21

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] ~New feature (non-breaking change which adds functionality)~
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):