### PR TITLE
Fix path of $INPUT_PROJECTBASEDIR

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,19 +11,19 @@ else
   SONAR_PASSWORD=""
 fi
 
-if [[ -f "${INPUT_PROJECTBASEDIR%/}pom.xml" ]]; then
+if [[ -f "${INPUT_PROJECTBASEDIR%/}/pom.xml" ]]; then
   echo "::error file=${INPUT_PROJECTBASEDIR%/}pom.xml::Maven project detected. You should run the goal 'org.sonarsource.scanner.maven:sonar' during build rather than using this GitHub Action."
   exit 1
 fi
 
-if [[ -f "${INPUT_PROJECTBASEDIR%/}build.gradle" ]]; then
+if [[ -f "${INPUT_PROJECTBASEDIR%/}/build.gradle" ]]; then
   echo "::error file=${INPUT_PROJECTBASEDIR%/}build.gradle::Gradle project detected. You should use the SonarQube plugin for Gradle during build rather than using this GitHub Action."
   exit 1
 fi
 
 unset JAVA_HOME
 
-if [[ ! -f "${INPUT_PROJECTBASEDIR%/}sonar-project.properties" ]]; then
+if [[ ! -f "${INPUT_PROJECTBASEDIR%/}/sonar-project.properties" ]]; then
   [[ -z "${INPUT_PROJECTKEY}" ]] && SONAR_PROJECTKEY="${REPOSITORY_NAME}" || SONAR_PROJECTKEY="${INPUT_PROJECTKEY}"
   [[ -z "${INPUT_PROJECTNAME}" ]] && SONAR_PROJECTNAME="${REPOSITORY_NAME}" || SONAR_PROJECTNAME="${INPUT_PROJECTNAME}"
   [[ -z "${INPUT_PROJECTVERSION}" ]] && SONAR_PROJECTVERSION="" || SONAR_PROJECTVERSION="${INPUT_PROJECTVERSION}"


### PR DESCRIPTION
### Description
Fix the path of checked files in `$INPUT_PROJECTBASEDIR`

### Motivation and Context
Currently if you use the action with a custom `sonar-project.properties` file, and leave the project basedir as default, it will not get the options of it as is checks the path: `.sonar-project.properties`

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~New feature (non-breaking change which adds functionality)~
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

### How Has This Been Tested?
You can test the substring removal locally to check everything:
```bash
$ basedir="." # default value

$ echo "${basedir%/}sonar-project.properties" # current
.sonar-project.properties

echo "${basedir%/}/sonar-project.properties" # new
./sonar-project.properties

# with trailing /
$ basedir="/test/123/" # custom value
echo "${basedir%/}/sonar-project.properties"
/test/123/sonar-project.properties

# without trailing /
$ basedir="/test/123"
$ echo "${basedir%/}/sonar-project.properties"
/test/123/sonar-project.properties
```