### PR TITLE
Remove default value for sonar.sources

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,6 @@ if [[ ! -f "${INPUT_PROJECTBASEDIR%/}/sonar-project.properties" ]]; then
     -Dsonar.projectBaseDir="${INPUT_PROJECTBASEDIR}" \
     -Dsonar.login="${INPUT_LOGIN}" \
     -Dsonar.password="${SONAR_PASSWORD}" \
-    -Dsonar.sources="${INPUT_PROJECTBASEDIR}" \
     -Dsonar.sourceEncoding="${INPUT_ENCODING}"
 else
   sonar-scanner \


### PR DESCRIPTION
### Description
Sonar already sets the `sonar.sources` to the base directory, as such there is non reason to force it as well in the action script. Moreover it overrides any attempt to set it from the properties file, preventing source filtering.

### Related Issue
Fixes #45 

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~New feature (non-breaking change which adds functionality)~
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Set up the property `sonar.sources` in a file `sonar-project.properties` to filter only some of the folder of a project (tested with multiple combinaisons)
- Run the action
- Check that the filter worked as expected (for every combinaisons)